### PR TITLE
make pi-bluetooth name more generic

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -90,7 +90,7 @@ slots:
   bcm-gpio-26:
     interface: gpio
     number: 26
-  pi-bluetooth:
+  bt-serial:
     interface: serial-port
     path: /dev/ttyAMA0
 


### PR DESCRIPTION
as discussed in LP #1674509, rename the device specific pi-bluetooth interface to have a less HW centric name, else bluez would have to add an interface for each board out there to snapcraft.yaml in the end.