### PR TITLE
dots in interface names are not allowed, fix spi

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -173,9 +173,9 @@ slots:
   bt-serial:
     interface: serial-port
     path: /dev/ttyAMA0
-  spidev0.0:
+  spidev0:
      interface: spi
      path: /dev/spidev0.0
-  spidev0.1:
+  spidev1:
      interface: spi
      path: /dev/spidev0.1


### PR DESCRIPTION
drop the dots in the spidev definitions to make them valid interfaces