### PR TITLE
Seed cloud-init from boot partition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,9 @@ endif
 	# configs
 	cp configs/cmdline.txt $(DESTDIR)/boot-assets/
 	cp configs/config.txt.$(ARCH) $(DESTDIR)/boot-assets/config.txt
+	cp configs/user-data* $(DESTDIR)/boot-assets/
+	cp configs/meta-data* $(DESTDIR)/boot-assets/
+	cp configs/network-config* $(DESTDIR)/boot-assets/
 	# gadget.yaml
 	mkdir -p $(DESTDIR)/meta
 	cp gadget.yaml $(DESTDIR)/meta/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else
 endif
 
 SOURCES_HOST ?= "/etc/apt/sources.list"
-SOURCES_MULTIVERSE := "$(STAGEDIR)/apt/mulitverse.sources.list"
+SOURCES_MULTIVERSE := "$(STAGEDIR)/apt/multiverse.sources.list"
 
 define stage_package
 	(cd $(2)/debs && apt-get download -o Dir::Etc::sourcelist=$(SOURCES_MULTIVERSE) -oAPT::Architecture=$(3) $(1);)
@@ -26,14 +26,6 @@ define enable_multiverse
 	cp $(SOURCES_HOST) $(SOURCES_MULTIVERSE)
 	sed -i "s/^\(deb.*\)\$$/\1 multiverse/" $(SOURCES_MULTIVERSE)
 	apt-get update -o Dir::Etc::sourcelist=$(SOURCES_MULTIVERSE) -oAPT::Architecture=$(ARCH) 2>/dev/null
-endef
-
-define workaround_missing_arm64_dtbs
-	mkdir -p $(STAGEDIR)/armhf/debs
-	apt-get update -o Dir::Etc::sourcelist=$(SOURCES_MULTIVERSE) -oAPT::Architecture=armhf 2>/dev/null
-	$(call stage_package,linux-modules-*-raspi2,$(STAGEDIR)/armhf,armhf)
-	cp $(STAGEDIR)/armhf/unpack/lib/firmware/*/device-tree/bcm2710-rpi-cm3.dtb \
-		$(STAGEDIR)/unpack/lib/firmware/*/device-tree/
 endef
 
 
@@ -61,12 +53,6 @@ endif
 	$(call stage_package,linux-firmware-raspi2,$(STAGEDIR),$(ARCH))
 	# devicetrees
 	$(call stage_package,linux-modules-*-raspi2,$(STAGEDIR),$(ARCH))
-	# XXX: Another temporary hack. The current linux-raspi2 arm64 kernel
-	# does not ship the CM3 dtb. Until this is fixed, we can use the armhf
-	# one as it is usable.
-ifeq ($(ARCH),arm64)
-	$(call workaround_missing_arm64_dtbs)
-endif
 	# Staging stage
 	mkdir -p $(DESTDIR)/boot-assets
 	# u-boot

--- a/configs/meta-data
+++ b/configs/meta-data
@@ -1,0 +1,1 @@
+instance_id: cloud-image

--- a/configs/network-config
+++ b/configs/network-config
@@ -1,0 +1,5 @@
+version: 2
+ethernets:
+    eth0:
+        dhcp4: true
+        optional: true

--- a/configs/user-data
+++ b/configs/user-data
@@ -1,0 +1,4 @@
+#cloud-config
+password: ubuntu
+chpasswd: ubuntu
+ssh_pwauth: True

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,3 +24,4 @@ parts:
     prime:
       - boot-assets/*
       - uboot*
+      - boot.scr


### PR DESCRIPTION
These changes add the cloud-init seed (meta-data, user-data, and network-config) to the boot partition. They also tidy up a redundant hack (for the compute module), and tweak the Makefile so we only download the .debs we actually require.