### PR TITLE
Update to u-boot v2019.04

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,7 +12,7 @@ parts:
   uboot:
     plugin: nil
     source: git://git.denx.de/u-boot.git
-    source-branch: v2017.05
+    source-branch: v2019.04
     prepare: |
       git apply ../../../uboot.patch
       make rpi_3_32b_defconfig

--- a/uboot.patch
+++ b/uboot.patch
@@ -1,35 +1,29 @@
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 4406366..1881f33 100644
+index 9ce41767a9..fbec105a11 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -117,7 +117,7 @@
- 					 sizeof(CONFIG_SYS_PROMPT) + 16)
+@@ -71,9 +71,14 @@
+ #define CONFIG_SYS_CBSIZE		1024
  
  /* Environment */
 -#define CONFIG_ENV_SIZE			SZ_16K
 +#define CONFIG_ENV_SIZE			SZ_128K
- #define CONFIG_ENV_IS_IN_FAT
- #define FAT_ENV_INTERFACE		"mmc"
- #define FAT_ENV_DEVICE_AND_PART		"0:1"
-@@ -125,7 +125,12 @@
- #define CONFIG_FAT_WRITE
- #define CONFIG_ENV_VARS_UBOOT_CONFIG
  #define CONFIG_SYS_LOAD_ADDR		0x1000000
 -#define CONFIG_PREBOOT			"usb start"
 +#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
 +/* Load environment from USB if no SD card */
 +#define CONFIG_PREBOOT			"usb start; if test ! \"mmc dev 0\"; then " \
-+	"fatload usb 0:1 0x3000000 "FAT_ENV_FILE"; " \
++	"fatload usb 0:1 0x3000000 "CONFIG_ENV_FAT_FILE,"; " \
 +	"env import -b 0x3000000; " \
 +	"fi;"
  
  /* Shell */
- #define CONFIG_SYS_MAXARGS		16
-@@ -139,6 +144,7 @@
+ 
+@@ -81,6 +86,7 @@
  #define CONFIG_SETUP_MEMORY_TAGS
  #define CONFIG_CMDLINE_TAG
  #define CONFIG_INITRD_TAG
 +#define CONFIG_SUPPORT_RAW_INITRD
  
- #include <config_distro_defaults.h>
- 
+ /* Environment */
+ #define ENV_DEVICE_SETTINGS \


### PR DESCRIPTION
Update to u-boot v2019.04 and refresh the u-boot patch as needed. The
reason for the update is fixing a bug for which loading some device tree
overlays from the first stage bootloader causes a u-boot crash. For
instance, adding the line

`dtoverlay=pi3-disable-bt`

to config.txt provokes this. This does not happen anymore in v2019.04.
Note that the pi3-disable-bt overlay disables the UART, so make sure you
have already eth access to the device when testing.