### PR TITLE
bump to newer raspberrypi fw to support CM3+

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -63,7 +63,7 @@ parts:
     prepare: |
       PACKAGES="http://ports.ubuntu.com/ubuntu-ports/dists/xenial-updates/universe/binary-armhf/Packages.gz"
       PKGPATH="$(wget -q -O- $PACKAGES|zcat|grep-dctrl linux-raspi2 |\
-        grep linux-image|grep Filename|tail -1| sed 's/^Filename: //')"
+        grep linux-modules|grep Filename|tail -1| sed 's/^Filename: //')"
       wget http://ports.ubuntu.com/ubuntu-ports/$PKGPATH
       dpkg -x $(basename $PKGPATH) unpack/
     install: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,6 +29,7 @@ parts:
       ln -s uboot.env $SNAPCRAFT_PART_INSTALL/uboot.conf
     build-packages:
       - bc
+      - bison
       - build-essential
       - device-tree-compiler
       - libpython2.7-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,7 +43,7 @@ parts:
     after:
       - uboot
     prepare: |
-      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20180919"
+      git clone --depth=1 https://github.com/raspberrypi/firmware.git -b "1.20190709"
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/boot-assets
       for file in fixup start bootcode LICENCE COPYING; do

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,7 +12,7 @@ parts:
   uboot:
     plugin: nil
     source: git://git.denx.de/u-boot.git
-    source-branch: v2017.05
+    source-branch: v2019.04
     prepare: |
       git apply ../../../uboot.patch
       make rpi_3_32b_defconfig

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,6 +32,7 @@ parts:
       - bison
       - build-essential
       - device-tree-compiler
+      - flex
       - libpython2.7-dev
       - python-minimal
       - on amd64 to armhf:

--- a/uboot.patch
+++ b/uboot.patch
@@ -1,35 +1,29 @@
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 4406366..1881f33 100644
+index 9ce41767a9..fbec105a11 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -117,7 +117,7 @@
- 					 sizeof(CONFIG_SYS_PROMPT) + 16)
+@@ -71,9 +71,14 @@
+ #define CONFIG_SYS_CBSIZE		1024
  
  /* Environment */
 -#define CONFIG_ENV_SIZE			SZ_16K
 +#define CONFIG_ENV_SIZE			SZ_128K
- #define CONFIG_ENV_IS_IN_FAT
- #define FAT_ENV_INTERFACE		"mmc"
- #define FAT_ENV_DEVICE_AND_PART		"0:1"
-@@ -125,7 +125,12 @@
- #define CONFIG_FAT_WRITE
- #define CONFIG_ENV_VARS_UBOOT_CONFIG
  #define CONFIG_SYS_LOAD_ADDR		0x1000000
 -#define CONFIG_PREBOOT			"usb start"
 +#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
 +/* Load environment from USB if no SD card */
 +#define CONFIG_PREBOOT			"usb start; if test ! \"mmc dev 0\"; then " \
-+	"fatload usb 0:1 0x3000000 "FAT_ENV_FILE"; " \
++	"fatload usb 0:1 0x3000000 "CONFIG_ENV_FAT_FILE,"; " \
 +	"env import -b 0x3000000; " \
 +	"fi;"
  
  /* Shell */
- #define CONFIG_SYS_MAXARGS		16
-@@ -139,6 +144,7 @@
+ 
+@@ -81,6 +86,7 @@
  #define CONFIG_SETUP_MEMORY_TAGS
  #define CONFIG_CMDLINE_TAG
  #define CONFIG_INITRD_TAG
 +#define CONFIG_SUPPORT_RAW_INITRD
  
- #include <config_distro_defaults.h>
- 
+ /* Environment */
+ #define ENV_DEVICE_SETTINGS \

--- a/uboot.patch
+++ b/uboot.patch
@@ -13,7 +13,7 @@ index 9ce41767a9..fbec105a11 100644
 +#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
 +/* Load environment from USB if no SD card */
 +#define CONFIG_PREBOOT			"usb start; if test ! \"mmc dev 0\"; then " \
-+	"fatload usb 0:1 0x3000000 "CONFIG_ENV_FAT_FILE,"; " \
++	"fatload usb 0:1 0x3000000 "CONFIG_ENV_FAT_FILE"; " \
 +	"env import -b 0x3000000; " \
 +	"fi;"
  


### PR DESCRIPTION
the super outdated firmware in this gadget can not boot CM3+ devices.
it also misses various fixes for HW features (temp/voltage etc)