### PR TITLE
Split classic boot configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,49 +49,42 @@ all: clean
 	fi
 	# XXX: This is a hack that we can hopefully get rid of once. Currently
 	# the livefs Launchpad builders don't have multiverse enabled.
-	# We wanto to work-around that by actually enabling multiverse just
+	# We want to work-around that by actually enabling multiverse just
 	# for this one build here as we need it for linux-firmware-raspi2.
 	$(call enable_multiverse)
+
 	# Preparation stage
 	mkdir -p $(STAGEDIR)/debs $(STAGEDIR)/unpack
-	# u-boot
 	$(call stage_package,flash-kernel,$(STAGEDIR),$(ARCH))
 	$(call stage_package,u-boot-rpi,$(STAGEDIR),$(ARCH))
-	cp boot.scr.in $(STAGEDIR)/boot.scr.in
-ifeq ($(ARCH),arm64)
-	sed -i s/bootz/booti/ $(STAGEDIR)/boot.scr.in
-endif
-	# boot-firmware
 	$(call stage_package,linux-firmware-raspi2,$(STAGEDIR),$(ARCH))
-	# devicetrees
 	$(call stage_package,linux-modules-*-raspi2,$(STAGEDIR),$(ARCH))
+
 	# Staging stage
+	mkdir -p $(DESTDIR)/boot-assets
 	mkimage -A $(MKIMAGE_ARCH) -O linux -T script -C none -n "boot script" \
 		-d $(STAGEDIR)/unpack/etc/flash-kernel/bootscript/bootscr.rpi* \
-		$(STAGEDIR)/boot.scr
-	mkdir -p $(DESTDIR)/boot-assets
-	# u-boot
+		$(DESTDIR)/boot-assets/boot.scr
 	for platform_path in $(STAGEDIR)/unpack/usr/lib/u-boot/*; do \
-		cp $$platform_path/u-boot.bin $(DESTDIR)/boot-assets/uboot_$${platform_path##*/}.bin; \
+		cp -a $$platform_path/u-boot.bin \
+			$(DESTDIR)/boot-assets/uboot_$${platform_path##*/}.bin; \
 	done
-	cp $(STAGEDIR)/boot.scr $(DESTDIR)
-	# boot-firmware
 	for file in fixup start bootcode; do \
-		cp $(STAGEDIR)/unpack/usr/lib/linux-firmware-raspi2/$${file}* $(DESTDIR)/boot-assets/; \
+		cp -a $(STAGEDIR)/unpack/usr/lib/linux-firmware-raspi2/$${file}* \
+			$(DESTDIR)/boot-assets/; \
 	done
-	# devicetrees
-	cp -a $(STAGEDIR)/unpack/lib/firmware/*/device-tree/* $(DESTDIR)/boot-assets
+	cp -a $(STAGEDIR)/unpack/lib/firmware/*/device-tree/* \
+		$(DESTDIR)/boot-assets
 ifeq ($(ARCH),arm64)
-	cp -a $(STAGEDIR)/unpack/lib/firmware/*/device-tree/broadcom/*.dtb $(DESTDIR)/boot-assets
+	cp -a $(STAGEDIR)/unpack/lib/firmware/*/device-tree/broadcom/*.dtb \
+		$(DESTDIR)/boot-assets
 endif
-	# configs
-	cp configs/*.txt $(DESTDIR)/boot-assets/
-	cp configs/config.txt.$(ARCH) $(DESTDIR)/boot-assets/config.txt
-	cp configs/user-data $(DESTDIR)/boot-assets/
-	cp configs/meta-data $(DESTDIR)/boot-assets/
-	cp configs/network-config $(DESTDIR)/boot-assets/
-	cp configs/README $(DESTDIR)/boot-assets/
-	# gadget.yaml
+	cp -a configs/*.txt $(DESTDIR)/boot-assets/
+	cp -a configs/config.txt.$(ARCH) $(DESTDIR)/boot-assets/config.txt
+	cp -a configs/user-data $(DESTDIR)/boot-assets/
+	cp -a configs/meta-data $(DESTDIR)/boot-assets/
+	cp -a configs/network-config $(DESTDIR)/boot-assets/
+	cp -a configs/README $(DESTDIR)/boot-assets/
 	mkdir -p $(DESTDIR)/meta
 	cp gadget.yaml $(DESTDIR)/meta/
 

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,8 @@ DESTDIR := "$(CURDIR)/install"
 ARCH ?= $(shell dpkg --print-architecture)
 SERIES ?= "bionic"
 ifeq ($(ARCH),arm64)
-	UBOOT_TARGET := "rpi_3"
-	UBOOT_BIN := "kernel8.img"
 	MKIMAGE_ARCH := "arm64"
 else
-	UBOOT_TARGET := "rpi_3_32b"
-	UBOOT_BIN := "uboot.bin"
 	MKIMAGE_ARCH := "arm"
 endif
 
@@ -70,7 +66,9 @@ endif
 	# Staging stage
 	mkdir -p $(DESTDIR)/boot-assets
 	# u-boot
-	cp $(STAGEDIR)/unpack/usr/lib/u-boot/$(UBOOT_TARGET)/u-boot.bin $(DESTDIR)/boot-assets/$(UBOOT_BIN)
+	for platform_path in $(STAGEDIR)/unpack/usr/lib/u-boot/*; do \
+		cp $$platform_path/u-boot.bin $(DESTDIR)/boot-assets/uboot_$${platform_path##*/}.bin; \
+	done
 	cp $(STAGEDIR)/boot.scr $(DESTDIR)
 	# boot-firmware
 	for file in fixup start bootcode; do \

--- a/Makefile
+++ b/Makefile
@@ -53,17 +53,20 @@ all: clean
 	# Preparation stage
 	mkdir -p $(STAGEDIR)/debs $(STAGEDIR)/unpack
 	# u-boot
+	$(call stage_package,flash-kernel,$(STAGEDIR),$(ARCH))
 	$(call stage_package,u-boot-rpi,$(STAGEDIR),$(ARCH))
 	cp boot.scr.in $(STAGEDIR)/boot.scr.in
 ifeq ($(ARCH),arm64)
 	sed -i s/bootz/booti/ $(STAGEDIR)/boot.scr.in
 endif
-	mkimage -A $(MKIMAGE_ARCH) -O linux -T script -C none -n "boot script" -d $(STAGEDIR)/boot.scr.in $(STAGEDIR)/boot.scr
 	# boot-firmware
 	$(call stage_package,linux-firmware-raspi2,$(STAGEDIR),$(ARCH))
 	# devicetrees
 	$(call stage_package,linux-modules-*-raspi2,$(STAGEDIR),$(ARCH))
 	# Staging stage
+	mkimage -A $(MKIMAGE_ARCH) -O linux -T script -C none -n "boot script" \
+		-d $(STAGEDIR)/unpack/etc/flash-kernel/bootscript/bootscr.rpi* \
+		$(STAGEDIR)/boot.scr
 	mkdir -p $(DESTDIR)/boot-assets
 	# u-boot
 	for platform_path in $(STAGEDIR)/unpack/usr/lib/u-boot/*; do \

--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,12 @@ ifeq ($(ARCH),arm64)
 	cp -a $(STAGEDIR)/unpack/lib/firmware/*/device-tree/broadcom/*.dtb $(DESTDIR)/boot-assets
 endif
 	# configs
-	cp configs/cmdline.txt $(DESTDIR)/boot-assets/
+	cp configs/*.txt $(DESTDIR)/boot-assets/
 	cp configs/config.txt.$(ARCH) $(DESTDIR)/boot-assets/config.txt
-	cp configs/user-data* $(DESTDIR)/boot-assets/
-	cp configs/meta-data* $(DESTDIR)/boot-assets/
-	cp configs/network-config* $(DESTDIR)/boot-assets/
+	cp configs/user-data $(DESTDIR)/boot-assets/
+	cp configs/meta-data $(DESTDIR)/boot-assets/
+	cp configs/network-config $(DESTDIR)/boot-assets/
+	cp configs/README $(DESTDIR)/boot-assets/
 	# gadget.yaml
 	mkdir -p $(DESTDIR)/meta
 	cp gadget.yaml $(DESTDIR)/meta/

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ else
 	MKIMAGE_ARCH := "arm"
 endif
 
+SERIES_HOST ?= $(shell lsb_release --codename --short)
 SOURCES_HOST ?= "/etc/apt/sources.list"
 SOURCES_MULTIVERSE := "$(STAGEDIR)/apt/multiverse.sources.list"
 
@@ -32,7 +33,8 @@ endef
 define enable_multiverse
 	mkdir -p $(STAGEDIR)/apt
 	cp $(SOURCES_HOST) $(SOURCES_MULTIVERSE)
-	sed -i "s/^\(deb.*\)\$$/\1 multiverse/" $(SOURCES_MULTIVERSE)
+	sed -i "/^deb/ s/\b$(SERIES_HOST)/$(SERIES)/" $(SOURCES_MULTIVERSE)
+	sed -i "/^deb/ s/$$/ multiverse/" $(SOURCES_MULTIVERSE)
 	apt-get update \
 		-o Dir::Etc::sourcelist=$(SOURCES_MULTIVERSE) \
 		-o APT::Architecture=$(ARCH) 2>/dev/null

--- a/boot.scr.in
+++ b/boot.scr.in
@@ -1,9 +1,0 @@
-setenv fdt_addr_r 0x03000000
-fdt addr ${fdt_addr_r}
-fdt get value bootargs /chosen bootargs
-setenv kernel_addr_r 0x01000000
-setenv ramdisk_addr_r 0x03100000
-fatload mmc 0:1 ${kernel_addr_r} vmlinuz
-fatload mmc 0:1 ${ramdisk_addr_r} initrd.img
-setenv initrdsize $filesize
-bootz ${kernel_addr_r} ${ramdisk_addr_r}:${initrdsize} ${fdt_addr_r}

--- a/configs/README
+++ b/configs/README
@@ -1,0 +1,26 @@
+An overview of the files on the /boot/firmware partition (the 1st partition
+on the SD card) used by the Ubuntu boot process (roughly in order) is as
+follows:
+
+* bootcode.bin   - this is the second stage bootloader loaded by all pis with
+                   the exception of the pi4 (where this is replaced by flash
+                   memory)
+* config.txt     - the first configuration file read by the boot process
+* syscfg.txt     - the file in which system modified configuration will be
+                   placed, included by config.txt
+* usercfg.txt    - the file in which user modified configuration should be
+                   placed, included by config.txt
+* start*.elf     - the third stage bootloader, which handles device-tree
+                   modification and which loads...
+* uboot*.bin     - various u-boot binaries for different pi platforms; these
+                   are launched as the "kernel" by config.txt
+* boot.scr       - the boot script executed by uboot*.bin which in turn
+                   loads...
+* vmlinuz        - the Linux kernel, executed by boot.scr
+* initrd.img     - the initramfs, executed by boot.scr
+* meta-data      - meta-data for cloud-init; usually just contains the
+                   instance id
+* network-config - network configuration for cloud-init; edit this to set up
+                   wifi access points and other networking settings
+* user-data      - user-data for cloud-init; edit this to configure initial
+                   users, SSH keys, packages, etc.

--- a/configs/btcfg.txt
+++ b/configs/btcfg.txt
@@ -1,0 +1,4 @@
+# See "nobtcfg.txt" for further information.
+
+enable_uart=0
+cmdline=btcmd.txt

--- a/configs/btcmd.txt
+++ b/configs/btcmd.txt
@@ -1,0 +1,1 @@
+net.ifnames=0 dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 elevator=deadline rootwait

--- a/configs/cmdline.txt
+++ b/configs/cmdline.txt
@@ -1,1 +1,0 @@
-net.ifnames=0 dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline rootwait

--- a/configs/config.txt.arm64
+++ b/configs/config.txt.arm64
@@ -12,7 +12,6 @@
 
 [pi4]
 kernel=uboot_rpi_4.bin
-dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 
 [pi2]
@@ -24,6 +23,7 @@ kernel=uboot_rpi_3.bin
 [all]
 arm_64bit=1
 device_tree_address=0x03000000
+dtoverlay=vc4-fkms-v3d
 
 # The following settings are "defaults" expected to be overridden by the
 # included configuration. The only reason they are included is, again, to

--- a/configs/config.txt.arm64
+++ b/configs/config.txt.arm64
@@ -12,6 +12,7 @@
 
 [pi4]
 kernel=uboot_rpi_4.bin
+dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 
 [pi2]

--- a/configs/config.txt.arm64
+++ b/configs/config.txt.arm64
@@ -1,6 +1,35 @@
-enable_uart=1
-kernel=kernel8.bin
-device_tree_address=0x03000000
-dtparam=i2c_arm=on
-dtparam=spi=on
+# Please DO NOT modify this file; if you need to modify the boot config, the
+# "usercfg.txt" file is the place to include user changes. Please refer to
+# the README file for a description of the various configuration files on
+# the boot partition.
+
+# The unusual ordering below is deliberate; older firmwares (in particular the
+# version initially shipped with bionic) don't understand the conditional
+# [sections] below and simply ignore them. The Pi4 doesn't boot at all with
+# firmwares this old so it's safe to place at the top. Of the Pi2 and Pi3, the
+# Pi3 uboot happens to work happily on the Pi2, so it needs to go at the bottom
+# to support old firmwares.
+
+[pi4]
+kernel=uboot_rpi_4.bin
+max_framebuffers=2
+
+[pi2]
+kernel=uboot_rpi_2.bin
+
+[pi3]
+kernel=uboot_rpi_3.bin
+
+[all]
 arm_64bit=1
+device_tree_address=0x03000000
+
+# The following settings are "defaults" expected to be overridden by the
+# included configuration. The only reason they are included is, again, to
+# support old firmwares which don't understand the "include" command.
+
+enable_uart=1
+cmdline=nobtcmd.txt
+
+include syscfg.txt
+include usercfg.txt

--- a/configs/config.txt.armhf
+++ b/configs/config.txt.armhf
@@ -12,7 +12,6 @@
 
 [pi4]
 kernel=uboot_rpi_4_32b.bin
-dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 
 [pi2]
@@ -23,6 +22,7 @@ kernel=uboot_rpi_3_32b.bin
 
 [all]
 device_tree_address=0x03000000
+dtoverlay=vc4-fkms-v3d
 
 # The following settings are "defaults" expected to be overridden by the
 # included configuration. The only reason they are included is, again, to

--- a/configs/config.txt.armhf
+++ b/configs/config.txt.armhf
@@ -1,5 +1,34 @@
-enable_uart=1
-kernel=uboot.bin
+# Please DO NOT modify this file; if you need to modify the boot config, the
+# "usercfg.txt" file is the place to include user changes. Please refer to
+# the README file for a description of the various configuration files on
+# the boot partition.
+
+# The unusual ordering below is deliberate; older firmwares (in particular the
+# version initially shipped with bionic) don't understand the conditional
+# [sections] below and simply ignore them. The Pi4 doesn't boot at all with
+# firmwares this old so it's safe to place at the top. Of the Pi2 and Pi3, the
+# Pi3 uboot happens to work happily on the Pi2, so it needs to go at the bottom
+# to support old firmwares.
+
+[pi4]
+kernel=uboot_rpi_4_32b.bin
+max_framebuffers=2
+
+[pi2]
+kernel=uboot_rpi_2.bin
+
+[pi3]
+kernel=uboot_rpi_3_32b.bin
+
+[all]
 device_tree_address=0x03000000
-dtparam=i2c_arm=on
-dtparam=spi=on
+
+# The following settings are "defaults" expected to be overridden by the
+# included configuration. The only reason they are included is, again, to
+# support old firmwares which don't understand the "include" command.
+
+enable_uart=1
+cmdline=nobtcmd.txt
+
+include syscfg.txt
+include usercfg.txt

--- a/configs/config.txt.armhf
+++ b/configs/config.txt.armhf
@@ -12,6 +12,7 @@
 
 [pi4]
 kernel=uboot_rpi_4_32b.bin
+dtoverlay=vc4-fkms-v3d
 max_framebuffers=2
 
 [pi2]

--- a/configs/meta-data
+++ b/configs/meta-data
@@ -1,1 +1,7 @@
+# This is the meta-data configuration file for cloud-init. Typically this just
+# contains the instance_id. Please refer to the cloud-init documentation for
+# more information:
+#
+# https://cloudinit.readthedocs.io/
+
 instance_id: cloud-image

--- a/configs/network-config
+++ b/configs/network-config
@@ -1,5 +1,30 @@
+# This file contains a netplan-compatible configuration which cloud-init
+# will apply on first-boot. Please refer to the cloud-init documentation and
+# the netplan reference for full details:
+#
+# https://cloudinit.readthedocs.io/
+# https://netplan.io/reference
+#
+# Some additional examples are commented out below
+
 version: 2
 ethernets:
-    eth0:
-        dhcp4: true
-        optional: true
+  eth0:
+    dhcp4: true
+    optional: true
+#wifis:
+#  wlan0:
+#    dhcp4: true
+#    optional: true
+#    access-points:
+#      homessid:
+#        password: "S3kr1t"
+#      myotherlan:
+#        password: "correct battery horse staple"
+#      workssid:
+#        auth:
+#          key-management: eap
+#          method: peap
+#          identity: "me@example.com"
+#          password: "passw0rd"
+#          ca-certificate: /etc/my_ca.pem

--- a/configs/nobtcfg.txt
+++ b/configs/nobtcfg.txt
@@ -8,4 +8,4 @@
 
 enable_uart=1
 cmdline=nobtcmd.txt
-dtoverlay=pi3-disable-bt
+#dtoverlay=pi3-disable-bt

--- a/configs/nobtcfg.txt
+++ b/configs/nobtcfg.txt
@@ -1,0 +1,11 @@
+# This configuration file sets the system up to support the serial console on
+# GPIOs 14 & 15. This is the default for Ubuntu on the Pi, but disables the use
+# of the Bluetooth module.
+#
+# If you wish to disable the serial console and use Bluetooth instead, install
+# the "pi-bluetooth" package then edit "syscfg.txt" to include "btcfg.txt"
+# instead of "nobtcfg.txt"
+
+enable_uart=1
+cmdline=nobtcmd.txt
+dtoverlay=pi3-disable-bt

--- a/configs/nobtcmd.txt
+++ b/configs/nobtcmd.txt
@@ -1,0 +1,1 @@
+net.ifnames=0 dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 root=LABEL=writable rootfstype=ext4 elevator=deadline rootwait

--- a/configs/syscfg.txt
+++ b/configs/syscfg.txt
@@ -1,0 +1,9 @@
+# This file is intended to contain system-made configuration changes. User
+# configuration changes should be placed in "usercfg.txt". Please refer to the
+# README file for a description of the various configuration files on the boot
+# partition.
+
+dtparam=i2c_arm=on
+dtparam=spi=on
+
+include nobtcfg.txt

--- a/configs/user-data
+++ b/configs/user-data
@@ -1,4 +1,73 @@
 #cloud-config
-password: ubuntu
-chpasswd: ubuntu
-ssh_pwauth: True
+
+# This is the user-data configuration file for cloud-init. By default this sets
+# up an initial user called "ubuntu" with password "ubuntu", which must be
+# changed at first login. However, many additional actions can be initiated on
+# first boot from this file. The cloud-init documentation has more details:
+#
+# https://cloudinit.readthedocs.io/
+#
+# Some additional examples are provided in comments below the default
+# configuration.
+
+# Enable password authentication with the SSH daemon
+ssh_pwauth: true
+
+# On first boot, set the (default) ubuntu user's password to "ubuntu" and
+# expire user passwords
+chpasswd:
+  expire: true
+  list:
+  - ubuntu:ubuntu
+
+## Add users and groups to the system, and import keys with the ssh-import-id
+## utility
+#groups:
+#- robot: [robot]
+#- robotics: [robot]
+#- pi
+#
+#users:
+#- default
+#- name: robot
+#  gecos: Mr. Robot
+#  primary_group: robot
+#  groups: users
+#  ssh_import_id: foobar
+#  lock_passwd: false
+#  passwd: $5$hkui88$nvZgIle31cNpryjRfO9uArF7DYiBcWEnjqq7L1AQNN3
+
+## Update apt database and upgrade packages on first boot
+#package_update: true
+#package_upgrade: true
+
+## Install additional packages on first boot
+#packages:
+#- pwgen
+#- pastebinit
+#- [libpython2.7, 2.7.3-0ubuntu3.1]
+
+## Write arbitrary files to the file-system (including binaries!)
+#write_files:
+#- path: /etc/default/keyboard
+#  content: |
+#    # KEYBOARD configuration file
+#    # Consult the keyboard(5) manual page.
+#    XKBMODEL="pc105"
+#    XKBLAYOUT="gb"
+#    XKBVARIANT=""
+#    XKBOPTIONS="ctrl: nocaps"
+#  permissions: '0644'
+#  owner: root:root
+#- encoding: gzip
+#  path: /usr/bin/hello
+#  content: !!binary |
+#    H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+#  owner: root:root
+#  permissions: '0755'
+
+## Run arbitrary commands at rc.local like time
+#runcmd:
+#- [ ls, -l, / ]
+#- [ sh, -xc, "echo $(date) ': hello world!'" ]
+#- [ wget, "http://ubuntu.com", -O, /run/mydir/index.html ]

--- a/configs/usercfg.txt
+++ b/configs/usercfg.txt
@@ -1,0 +1,3 @@
+# Place "config.txt" changes (dtparam, dtoverlay, disable_overscan, etc.) in
+# this file. Please refer to the README file for a description of the various
+# configuration files on the boot partition.

--- a/gadget.yaml
+++ b/gadget.yaml
@@ -11,5 +11,3 @@ volumes:
         content:
           - source: boot-assets/
             target: /
-          - source: boot.scr
-            target: boot.scr

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,5 +23,3 @@ parts:
       cp -a install/* $SNAPCRAFT_PART_INSTALL/
     prime:
       - boot-assets/*
-      - uboot*
-      - boot.scr


### PR DESCRIPTION
This is a fairly complex PR that moves the classic branch closer to the core branch in preparation for eventual merging (although this is not yet that merge as other things need to happen in snapd and flash-kernel for that to occur), and splits the boot configuration for easier maintenance. Specifically, this PR:

* Splits the boot configuration into a series of configuration files, most of which are not (intended to be) user-editable
* Instead of copying a single u-boot binary to the boot partition, copies all u-boot binaries from the u-boot package under different filenames (which the new config.txt will select according to platform); this is how core already does things (albeit from a different source, as core builds its own u-boot binaries)
* Uses the boot.scr uboot script from the flash-kernel package instead of a (redundant) one that was included in this branch (this is another move in preparation for merging with core as the pi boot script in flash-kernel will eventually support both platforms)
* Includes the option to use a different series than the builder's for packages

For review, I would recommend going through the commits individually then looking at the end state rather than trying to review the overall diff.