### PR TITLE
FK templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,21 @@ all: clean
 
 	# Staging stage
 	mkdir -p $(DESTDIR)/boot-assets
+	# NOTE: the bootscr.rpi* below is deliberate; older flash-kernels have
+	# separate bootscr.rpi? files for different pis, while newer have a
+	# single generic bootscr.rpi file
+	for kvers in $(STAGEDIR)/unpack/lib/modules/*; do \
+		sed \
+			-e "s/@@KERNEL_VERSION@@/$${kvers##*/}/g" \
+			-e "s/@@LINUX_KERNEL_CMDLINE@@/quiet splash/g" \
+			-e "s/@@LINUX_KERNEL_CMDLINE_DEFAULTS@@//g" \
+			-e "s/@@UBOOT_ENV_EXTRA@@//g" \
+			-e "s/@@UBOOT_PREBOOT_EXTRA@@//g" \
+			$(STAGEDIR)/unpack/etc/flash-kernel/bootscript/bootscr.rpi* \
+			> $(STAGEDIR)/unpack/bootscr.rpi; \
+	done
 	mkimage -A $(MKIMAGE_ARCH) -O linux -T script -C none -n "boot script" \
-		-d $(STAGEDIR)/unpack/etc/flash-kernel/bootscript/bootscr.rpi* \
-		$(DESTDIR)/boot-assets/boot.scr
+		-d $(STAGEDIR)/unpack/bootscr.rpi $(DESTDIR)/boot-assets/boot.scr
 	for platform_path in $(STAGEDIR)/unpack/usr/lib/u-boot/*; do \
 		cp -a $$platform_path/u-boot.bin \
 			$(DESTDIR)/boot-assets/uboot_$${platform_path##*/}.bin; \

--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,11 @@ all: clean
 		cp -a $(STAGEDIR)/unpack/usr/lib/linux-firmware-raspi2/$${file}* \
 			$(DESTDIR)/boot-assets/; \
 	done
-	cp -a $(STAGEDIR)/unpack/lib/firmware/*/device-tree/* \
-		$(DESTDIR)/boot-assets
-ifeq ($(ARCH),arm64)
-	cp -a $(STAGEDIR)/unpack/lib/firmware/*/device-tree/broadcom/*.dtb \
-		$(DESTDIR)/boot-assets
-endif
+	cp -a $$(find $(STAGEDIR)/unpack/lib/firmware/*/device-tree -name "*.dtb") \
+		$(DESTDIR)/boot-assets/
+	mkdir -p $(DESTDIR)/boot-assets/overlays
+	cp -a $$(find $(STAGEDIR)/unpack/lib/firmware/*/device-tree -name "*.dtbo") \
+		$(DESTDIR)/boot-assets/overlays/
 	cp -a configs/*.txt $(DESTDIR)/boot-assets/
 	cp -a configs/config.txt.$(ARCH) $(DESTDIR)/boot-assets/config.txt
 	cp -a configs/user-data $(DESTDIR)/boot-assets/

--- a/configs/config.txt.arm64
+++ b/configs/config.txt.arm64
@@ -23,7 +23,6 @@ kernel=uboot_rpi_3.bin
 [all]
 arm_64bit=1
 device_tree_address=0x03000000
-dtoverlay=vc4-fkms-v3d
 
 # The following settings are "defaults" expected to be overridden by the
 # included configuration. The only reason they are included is, again, to

--- a/configs/config.txt.armhf
+++ b/configs/config.txt.armhf
@@ -22,7 +22,6 @@ kernel=uboot_rpi_3_32b.bin
 
 [all]
 device_tree_address=0x03000000
-dtoverlay=vc4-fkms-v3d
 
 # The following settings are "defaults" expected to be overridden by the
 # included configuration. The only reason they are included is, again, to


### PR DESCRIPTION
Ensure that any flash-kernel templates that appear in the boot-scripts are substituted correctly (mostly blank, but there's a couple of exceptions). The only tricky one is the @@KERNEL_VERSION@@ template (which we don't actually use even in the new boot-script, but we might as well implement in case it ever gets used in the future). In this case it gets taken from the name of a dir in the linux-modules-*-raspi2 package - which is a bit of a hack but should be reliable enough?

Also tidied up device-tree and overlay copying (arm64 and armhf bizarrely have different dirs for their device-trees and the former code wound up making a redundant copy of them in the arm64 case), and removed the dtoverlay which was preventing the 3A+ from booting (this change requires the new kernel intended to fix the Pi4 USB issue).