### PR TITLE
Use fixrtc to workaround lack of RTC

### DIFF
--- a/configs/btcmd.txt
+++ b/configs/btcmd.txt
@@ -1,1 +1,1 @@
-net.ifnames=0 dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 elevator=deadline rootwait
+net.ifnames=0 dwc_otg.lpm_enable=0 console=tty1 root=LABEL=writable rootfstype=ext4 elevator=deadline rootwait fixrtc

--- a/configs/nobtcmd.txt
+++ b/configs/nobtcmd.txt
@@ -1,1 +1,1 @@
-net.ifnames=0 dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 root=LABEL=writable rootfstype=ext4 elevator=deadline rootwait
+net.ifnames=0 dwc_otg.lpm_enable=0 console=ttyAMA0,115200 console=tty1 root=LABEL=writable rootfstype=ext4 elevator=deadline rootwait fixrtc


### PR DESCRIPTION
Without fixrtc, fsck can get confused about the superblock being in the
future (because Pis lack a built-in RTC).